### PR TITLE
[depends] librtmp: openssl 1.1 patch fixes

### DIFF
--- a/depends/common/librtmp/0003-openssl-1.1.patch
+++ b/depends/common/librtmp/0003-openssl-1.1.patch
@@ -1,6 +1,6 @@
 --- a/librtmp/dh.h
 +++ b/librtmp/dh.h
-@@ -253,20 +253,44 @@
+@@ -253,20 +253,42 @@
    if (!dh)
      goto failed;
  
@@ -14,8 +14,6 @@
 +  MP_new(g);
 +  if (!g)
 +    goto failed;
-+
-+  DH_set0_pqg(dh, NULL, g, NULL);
 +#endif
  
 +#if !defined(USE_OPENSSL) || !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -34,7 +32,7 @@
    MP_set_w(dh->g, 2);	/* base 2 */
 +#else
 +  MP_set_w(g, 2);   /* base 2 */
-+  DH_set0_pqg(dh, NULL, g, NULL);
++  DH_set0_pqg(dh, p, NULL, g);
 +#endif
  
 +#if !defined(USE_OPENSSL) || !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -45,7 +43,7 @@
    return dh;
  
  failed:
-@@ -293,12 +317,24 @@
+@@ -293,12 +315,24 @@
        MP_gethex(q1, Q1024, res);
        assert(res);
  
@@ -70,7 +68,7 @@
  	}
  
        MP_free(q1);
-@@ -314,15 +350,29 @@
+@@ -314,15 +348,29 @@
  DHGetPublicKey(MDH *dh, uint8_t *pubkey, size_t nPubkeyLen)
  {
    int len;
@@ -100,7 +98,7 @@
    return 1;
  }
  
-@@ -364,7 +414,13 @@
+@@ -364,7 +412,13 @@
    MP_gethex(q1, Q1024, len);
    assert(len);
  
@@ -158,7 +156,7 @@
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +#define HMAC_setup(ctx, key, len)	HMAC_CTX_init(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#else
-+#define HMAC_setup(ctx, key, len)       HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
++#define HMAC_setup(ctx, key, len)	ctx = HMAC_CTX_new(); HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#endif
 +#define HMAC_crunch(ctx, buf, len)	HMAC_Update(ctx, buf, len)
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -225,7 +223,7 @@
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +#define HMAC_setup(ctx, key, len)	HMAC_CTX_init(ctx); HMAC_Init_ex(ctx, (unsigned char *)key, len, EVP_sha256(), 0)
 +#else
-+#define HMAC_setup(ctx, key, len) HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, (unsigned char *)key, len, EVP_sha256(), 0)
++#define HMAC_setup(ctx, key, len)	ctx = HMAC_CTX_new(); HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#endif
 +#define HMAC_crunch(ctx, buf, len)	HMAC_Update(ctx, (unsigned char *)buf, len)
 +#define HMAC_finish(ctx, dig, dlen)	HMAC_Final(ctx, (unsigned char *)dig, &dlen);

--- a/depends/windows/librtmp/0003-openssl-1.1.patch
+++ b/depends/windows/librtmp/0003-openssl-1.1.patch
@@ -1,6 +1,6 @@
 --- a/librtmp/dh.h
 +++ b/librtmp/dh.h
-@@ -253,20 +253,44 @@
+@@ -253,20 +253,42 @@
    if (!dh)
      goto failed;
  
@@ -14,8 +14,6 @@
 +  MP_new(g);
 +  if (!g)
 +    goto failed;
-+
-+  DH_set0_pqg(dh, NULL, g, NULL);
 +#endif
  
 +#if !defined(USE_OPENSSL) || !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -34,7 +32,7 @@
    MP_set_w(dh->g, 2);	/* base 2 */
 +#else
 +  MP_set_w(g, 2);   /* base 2 */
-+  DH_set0_pqg(dh, NULL, g, NULL);
++  DH_set0_pqg(dh, p, NULL, g);
 +#endif
  
 +#if !defined(USE_OPENSSL) || !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -45,7 +43,7 @@
    return dh;
  
  failed:
-@@ -293,12 +317,24 @@
+@@ -293,12 +315,24 @@
        MP_gethex(q1, Q1024, res);
        assert(res);
  
@@ -70,7 +68,7 @@
  	}
  
        MP_free(q1);
-@@ -314,15 +350,29 @@
+@@ -314,15 +348,29 @@
  DHGetPublicKey(MDH *dh, uint8_t *pubkey, size_t nPubkeyLen)
  {
    int len;
@@ -100,7 +98,7 @@
    return 1;
  }
  
-@@ -364,7 +414,13 @@
+@@ -364,7 +412,13 @@
    MP_gethex(q1, Q1024, len);
    assert(len);
  
@@ -158,7 +156,7 @@
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +#define HMAC_setup(ctx, key, len)	HMAC_CTX_init(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#else
-+#define HMAC_setup(ctx, key, len)       HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
++#define HMAC_setup(ctx, key, len)	ctx = HMAC_CTX_new(); HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#endif
 +#define HMAC_crunch(ctx, buf, len)	HMAC_Update(ctx, buf, len)
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -225,7 +223,7 @@
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +#define HMAC_setup(ctx, key, len)	HMAC_CTX_init(ctx); HMAC_Init_ex(ctx, (unsigned char *)key, len, EVP_sha256(), 0)
 +#else
-+#define HMAC_setup(ctx, key, len) HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, (unsigned char *)key, len, EVP_sha256(), 0)
++#define HMAC_setup(ctx, key, len)	ctx = HMAC_CTX_new(); HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#endif
 +#define HMAC_crunch(ctx, buf, len)	HMAC_Update(ctx, (unsigned char *)buf, len)
 +#define HMAC_finish(ctx, dig, dlen)	HMAC_Final(ctx, (unsigned char *)dig, &dlen);


### PR DESCRIPTION
These updates of the 0003openssl1.1 patch files should fix issues with rtmpe streams and swf hash auto-calculation causing core dumps and Kodi crashes when using the locally built version of the addon.

For more info, refer to https://github.com/xbmc/inputstream.rtmp/issues/45

Cheers,

Jx-